### PR TITLE
fix(sunburst): pass more data to color method

### DIFF
--- a/src/models/sunburst.js
+++ b/src/models/sunburst.js
@@ -235,15 +235,15 @@ nv.models.sunburst = function() {
 
             cGE.append("path")
                 .attr("d", arc)
-                .style("fill", function (d) {
+                .style("fill", function (d, i) {
                     if (d.color) {
                         return d.color;
                     }
                     else if (groupColorByParent) {
-                        return color((d.children ? d : d.parent).name);
+                        return color((d.children ? d : d.parent), i);
                     }
                     else {
-                        return color(d.name);
+                        return color(d, i);
                     }
                 })
                 .style("stroke", "#FFF")


### PR DESCRIPTION
This fix passes the entire data object and index into the color function rather than just the name. In addition to to allowing more intelligent color functions, this change makes the API more consistent with the pie chart.

BREAKING CHANGE:

Any existing sunburst chart that uses a custom color function will need to be updated to the new api; however, the name is still passed to this function as an attribute of the object.